### PR TITLE
Allow the mirador viewer to take up the entire workspace view.

### DIFF
--- a/app/assets/stylesheets/workspace.scss
+++ b/app/assets/stylesheets/workspace.scss
@@ -1,6 +1,14 @@
+.workspaces-show {
+  .container-fluid {
+    margin: 0;
+    padding: 0;
+  }
+}
+
 #viewer {
+  clear: both;
   display: block;
-  height: 600px;
-  position: relative;
+  height: calc(100% - 55px); // should be $navbar-brand-height but the variable is not available
+  position: fixed;
   width: 100%;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     collections_path
   end
+
+  def body_classes
+    [controller_name, action_name].join('-')
+  end
+
+  helper_method :body_classes
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -14,6 +14,7 @@ class Collection < ApplicationRecord
       imagePath: '',
       i18nPath: '',
       data: manifest_urls.map { |manifest_url| { manifestUri: manifest_url } },
+      openManifestsPage: true,
       mainMenuSettings: {
         userButtons: [
           {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
+  <body class="<%= body_classes %>">
     <%= render 'shared/header' %>
     <div class='container-fluid'>
       <%= yield %>

--- a/app/views/workspaces/show.html.erb
+++ b/app/views/workspaces/show.html.erb
@@ -7,5 +7,3 @@
     );
   });
 </script>
-
-<%= link_to 'Back', workspaces_path %>

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -46,5 +46,9 @@ RSpec.describe Collection, type: :model do
       user_buttons = subject.mirador_options[:mainMenuSettings][:userButtons]
       expect(user_buttons[0][:label]).to eq 'Save'
     end
+
+    it 'forces the load window to open' do
+      expect(subject.mirador_options[:openManifestsPage]).to be true
+    end
   end
 end

--- a/spec/views/workspaces/show.html.erb_spec.rb
+++ b/spec/views/workspaces/show.html.erb_spec.rb
@@ -12,8 +12,4 @@ RSpec.describe 'workspaces/show', type: :view do
   it 'renders a mirador script tag' do
     expect(rendered).to have_css('script', text: /Mirador/, visible: false)
   end
-
-  it 'renders a back link' do
-    expect(rendered).to have_link 'Back'
-  end
 end


### PR DESCRIPTION
Closes #49 

<img width="1050" alt="updated-workspace-view" src="https://cloud.githubusercontent.com/assets/96776/24739878/134d5ef4-1a53-11e7-8190-afab4b1f9c4e.png">