### PR TITLE
Fix box-sizing issues from different normalize versions

### DIFF
--- a/app/assets/stylesheets/mirador_sul.scss
+++ b/app/assets/stylesheets/mirador_sul.scss
@@ -3,3 +3,16 @@
 @import 'header';
 @import 'home';
 @import 'workspace';
+
+// Mirador does not like the Bootstrap reboot box-sizing from reboot.scss
+// see https://github.com/twbs/bootstrap/blob/v4-dev/scss/_reboot.scss
+
+html .mirador-viewer {
+  box-sizing: content-box;
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: content-box; // 1
+  }
+}


### PR DESCRIPTION
Mirador and Bootstrap4 use 2 different versions of normalize which can
cause some issues here.