### PR TITLE
Sort collections by newest first (by default)?

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,8 @@
 class Collection < ApplicationRecord
   validates :name, presence: true
 
+  default_scope { order(created_at: :desc) }
+
   belongs_to :user
 
   has_and_belongs_to_many :manifests

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -8,6 +8,19 @@ RSpec.describe Collection, type: :model do
     expect(subject.user).to be_a(User)
   end
 
+  describe 'scopes' do
+    describe 'default' do
+      it 'orders by the created date so that the most recently created are first' do
+        old_collection = create(:collection, created_at: Time.zone.today - 1.day)
+        new_collection = create(:collection)
+        all_collections = Collection.all
+
+        expect(all_collections.first).to eq new_collection
+        expect(all_collections.last).to eq old_collection
+      end
+    end
+  end
+
   context 'with many manifests' do
     before do
       (1..n).each { subject.manifests << create(:manifest) }


### PR DESCRIPTION
I _think_ in all contexts that we're listing collections we're going to want to have the newest at the top by default.