### PR TITLE
Implement annotation service and backend

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ AllCops:
     - 'Gemfile'
     - 'Capfile'
     - 'vendor/bundle/**/*'
+
+RSpec/ExpectActual:
+  Exclude:
+    - 'spec/routing/*.rb'

--- a/app/assets/javascripts/custom_annotation_endpoint.js
+++ b/app/assets/javascripts/custom_annotation_endpoint.js
@@ -1,0 +1,176 @@
+/*
+ * annotationsList - current list of OA Annotations
+ * dfd - Deferred Object
+ * init()
+ * search(options, successCallback, errorCallback)
+ * create(oaAnnotation, successCallback, errorCallback)
+ * update(oaAnnotation, successCallback, errorCallback)
+ * deleteAnnotation(annotationID, successCallback, errorCallback)
+ *
+ * getAnnotationInOA(endpointAnnotation)
+ * getAnnotationInEndpoint(oaAnnotation)
+ */
+(function($){
+
+  $.Endpoint = function(options) {
+
+    jQuery.extend(this, {
+      dfd:             null,
+      annotationsList: [],  // OA list for Mirador use
+      windowID:        null,
+      eventEmitter:    null
+    }, options);
+
+    this.init();
+  };
+
+  $.Endpoint.prototype = {
+    init: function() {},
+
+    // Search endpoint for all annotations with a given URI in options
+    search: function(options, successCallback, errorCallback) {
+      var _this = this;
+      _this.annotationsList = [];
+
+      jQuery.ajax({
+        url: _this.endpoint,
+        type: 'GET',
+        dataType: 'json',
+        headers: { },
+        data: options,  // options.uri contains the Canvas URI
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback(data);
+          } else {
+            jQuery.each(data, function(index, value) {
+              _this.annotationsList.push(_this.getAnnotationInOA(value));
+            });
+            _this.dfd.resolve(true);
+          }
+        },
+        error: function(data) {
+          if (typeof errorCallback === "function") {
+            errorCallback(data);
+          } else {
+            console.log("The request for annotations has caused an error for endpoint: " + options.uri);
+          }
+        }
+      });
+    },
+
+    // Delete an annotation by endpoint identifier
+    deleteAnnotation: function(annotationID, successCallback, errorCallback) {
+      var _this = this;
+      jQuery.ajax({
+        url: _this.endpoint + '/' + annotationID,
+        type: 'DELETE',
+        dataType: 'json',
+        headers: {
+          'X-CSRF-Token': _this.csrfToken()
+        },
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback();
+          }
+        },
+        error: function() {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    // Update an annotation given the OA version
+    update: function(oaAnnotation, successCallback, errorCallback) {
+      var annotation = this.getAnnotationInEndpoint(oaAnnotation),
+      _this = this;
+
+      jQuery.ajax({
+        url: _this.endpoint + '/' + annotationID,
+        type: 'PATCH',
+        dataType: 'json',
+        headers: {
+          'X-CSRF-Token': _this.csrfToken()
+        },
+        data: JSON.stringify(annotation),
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback();
+          }
+        },
+        error: function() {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    // Takes OA Annotation, gets Endpoint Annotation, and saves
+    // if successful, MUST return the OA rendering of the annotation
+    create: function(oaAnnotation, successCallback, errorCallback) {
+      var _this = this;
+      var annotation = _this.getAnnotationInEndpoint(oaAnnotation);
+      jQuery.ajax({
+        url: _this.endpoint,
+        type: 'POST',
+        headers: {
+          'X-CSRF-Token': _this.csrfToken()
+        },
+        data: JSON.stringify(annotation),
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback(_this.getAnnotationInOA(data));
+          }
+        },
+        error: function() {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    set: function(prop, value, options) {
+      if (options) {
+        this[options.parent][prop] = value;
+      } else {
+        this[prop] = value;
+      }
+    },
+
+    //Convert Endpoint annotation to OA
+    getAnnotationInOA: function(annotation) {
+      return annotation;
+    },
+
+    // Converts OA Annotation to endpoint format
+    getAnnotationInEndpoint: function(oaAnnotation) {
+      var uuid = Mirador.genUUID();
+      oaAnnotation["@id"] = uuid;
+      canvas = oaAnnotation.on[0].full;
+      return {
+        annotation: {
+          uuid: uuid,
+          data: JSON.stringify(oaAnnotation),
+          canvas: canvas
+        }
+      };    },
+
+    userAuthorize: function(action, annotation) {
+      return true;  // allow all
+    },
+
+    csrfToken: function() {
+      // We need to monkey patch this since $ !== jQuery in Mirador context
+      return jQuery('meta[name=csrf-token]').attr('content');
+    },
+
+  };
+
+}(Mirador));

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,0 +1,38 @@
+##
+# Controller that handles Annotation CRUD
+class AnnotationsController < ApplicationController
+  before_action :authenticate_user!
+  load_and_authorize_resource
+
+  # GET /annotations
+  def index
+    @annotations = Annotation.accessible_by(current_ability).where(canvas: annotation_search_params)
+  end
+
+  # POST /annotations
+  def create
+    @annotation = Annotation.new(annotation_params)
+    @annotation.user = current_user
+    if @annotation.save
+      render json: @annotation.data
+    else
+      render status: :bad_request, body: t('annotations.create_error')
+    end
+  end
+
+  # DELETE /annotation/:id
+  def destroy
+    @annotation.destroy
+    render status: :accepted, body: t('annotations.destroy')
+  end
+
+  private
+
+  def annotation_params
+    params.require(:annotation).permit(:uuid, :data, :canvas)
+  end
+
+  def annotation_search_params
+    params.require(:uri)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,7 @@ class Ability
     can :manage, Collection, user_id: user.id
     can :manage, Manifest, user_id: user.id
     can :manage, Workspace, user_id: user.id
+    can :manage, Annotation, user_id: user.id
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
   end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,0 +1,10 @@
+##
+# Annotation model
+class Annotation < ApplicationRecord
+  validates :uuid, presence: true
+  validates :canvas, presence: true
+
+  belongs_to :user
+
+  serialize :data, JSON
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :collections
   has_many :manifests, -> { distinct }, through: :collections # the User's library
+  has_many :annotations
 end

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -14,7 +14,15 @@ class Workspace < ApplicationRecord
   # Proxying data through mirador_options
   # for consistency with Collection
   def mirador_options
-    merge_user_logo(JSON.parse(data)).to_json
+    config = merge_user_logo(JSON.parse(data)).deep_symbolize_keys
+    config[:annotationEndpoint] = {
+      name: 'Storage',
+      module: 'Endpoint',
+      options: {
+        endpoint: Rails.application.routes.url_helpers.annotations_path
+      }
+    }
+    config.to_json
   end
 
   private

--- a/app/views/annotations/index.json.erb
+++ b/app/views/annotations/index.json.erb
@@ -1,0 +1,1 @@
+<%= @annotations.map{ |a| JSON.parse(a.data )}.to_json.html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,3 +66,9 @@ en:
     workspace:
       destroy: Delete workspace
       edit: Edit workspace
+  annotations:
+    create: Annotation was successfully created.
+    create_error: There was a problem creating the annotation.
+    index:
+      header: "Annotations for Workspace %{name}"
+    destroy: Annotation was successfully destroyed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :workspaces, only: [:index, :show, :destroy, :edit, :update]
+  resources :annotations, except: [:new, :edit, :update], defaults: { format: :json }
 
   mount MiradorRails::Engine, at: MiradorRails::Engine.locales_mount_path
 end

--- a/db/migrate/20170401011619_create_annotations.rb
+++ b/db/migrate/20170401011619_create_annotations.rb
@@ -1,0 +1,14 @@
+class CreateAnnotations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :annotations do |t|
+      t.references :user, foreign_key: true
+      t.string :uuid
+      t.string :canvas
+      t.binary :data
+
+      t.timestamps
+    end
+    add_index :annotations, :uuid
+    add_index :annotations, :canvas
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,13 +12,25 @@
 
 ActiveRecord::Schema.define(version: 20170410164012) do
 
+  create_table "annotations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "uuid"
+    t.string   "canvas"
+    t.binary   "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canvas"], name: "index_annotations_on_canvas"
+    t.index ["user_id"], name: "index_annotations_on_user_id"
+    t.index ["uuid"], name: "index_annotations_on_uuid"
+  end
+
   create_table "collections", force: :cascade do |t|
     t.string   "name"
     t.integer  "user_id"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "description"
     t.integer  "workspaces_count", default: 0
+    t.text     "description"
     t.index ["user_id"], name: "index_collections_on_user_id"
   end
 

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe AnnotationsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:valid_attributes) do
+    {
+      uuid: 'abc-123-do-re-mi',
+      canvas: 'http://www.example.com/canvas',
+      data: 'super cool anno data'
+    }
+  end
+  let(:invalid_attributes) do
+    {
+      uuid: ''
+    }
+  end
+  before { sign_in user }
+
+  describe 'GET #index' do
+    before do
+      create_list(:annotation, 2, user: user)
+      create(:annotation, user: user, canvas: 'http://www.example.com/bad')
+      create(:annotation, canvas: 'http://www.example.com/hola')
+    end
+    it 'returns annotations that have the correct canvas uri' do
+      get :index, params: { uri: 'http://www.example.com/hola', format: :json }
+      expect(response.status).to eq 200
+      expect(assigns(:annotations).length).to eq 2
+    end
+    it 'requires uri parameter' do
+      expect { get :index, params: { format: :json } }.to raise_error ActionController::ParameterMissing, /uri/
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid parameters' do
+      it 'creates a new Annotation' do
+        expect do
+          post :create, params: { format: :json, annotation: valid_attributes }
+        end.to change(Annotation, :count).by(1)
+      end
+
+      it 'assigns @annotation' do
+        post :create, params: { format: :json, annotation: valid_attributes }
+        expect(assigns(:annotation)).to be_a Annotation
+      end
+
+      it 'returns persited annotation data' do
+        post :create, params: { format: :json, annotation: valid_attributes }
+        expect(response.body).to eq 'super cool anno data'
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'responds with a 400' do
+        post :create, params: { format: :json, annotation: invalid_attributes }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to eq 'There was a problem creating the annotation.'
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let(:annotation) { Annotation.create! valid_attributes }
+    before do
+      annotation.user = user
+      annotation.save
+    end
+    it 'destroys the requested annotation' do
+      expect do
+        delete :destroy, params: { format: :json, id: annotation.to_param }
+      end.to change(Annotation, :count).by(-1)
+    end
+
+    it 'responds with accepted' do
+      delete :destroy, params: { format: :json, id: annotation.to_param }
+      expect(response).to have_http_status(:accepted)
+      expect(response.body).to eq 'Annotation was successfully destroyed.'
+    end
+  end
+end

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :annotation do
+    user
+    uuid 'MyString'
+    canvas 'http://www.example.com/hola'
+    data ''
+  end
+end

--- a/spec/features/manifest_management_spec.rb
+++ b/spec/features/manifest_management_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Manifest Management', type: :feature do
       expect(page).to have_css 'li', text: 'http://example.com/iiif/manifest2.json'
       click_link 'Destroy'
 
-      expect('Manifest was successfully destroyed.')
+      expect(page).to have_content('Manifest was successfully destroyed.')
       expect(page).not_to have_css 'li', text: 'http://example.com/iiif/manifest2.json'
     end
   end

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Annotation, type: :model do
+  describe 'validations' do
+    it 'requires uuid' do
+      expect do
+        described_class.create!(canvas: 'yolo')
+      end.to raise_error(ActiveRecord::RecordInvalid, /Uuid/)
+    end
+    it 'requires canvas' do
+      expect do
+        described_class.create!(uuid: 'yolo')
+      end.to raise_error(ActiveRecord::RecordInvalid, /Canvas/)
+    end
+  end
+end

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Annotations', type: :request do
+  describe 'GET /annotations' do
+    it 'requires authorization' do
+      get annotations_path
+      expect(response).to have_http_status(401)
+    end
+  end
+end

--- a/spec/routing/annotations_routing_spec.rb
+++ b/spec/routing/annotations_routing_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe AnnotationsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/annotations').to route_to(controller: 'annotations', action: 'index', format: :json)
+    end
+
+    it 'routes to #create' do
+      expect(post: '/annotations').to route_to(controller: 'annotations', action: 'create', format: :json)
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/annotations/1').to route_to(controller: 'annotations', action: 'destroy', id: '1', format: :json)
+    end
+  end
+end


### PR DESCRIPTION
Closes #5 

Adds the ability to save and recall annos created by a user. Does not yet implement update and delete on the client side (I believe there will be some Mirador modifications needed?).

I also tried to add a feature spec for this but poltergeist and mirador were not playing nicely together. Open to suggestions here I spent about 1.5 hours to try and get it to work unsuccessfully.

![annos](https://cloud.githubusercontent.com/assets/1656824/24916235/92737260-1ea7-11e7-9eae-635d4e4b12e8.gif)
